### PR TITLE
Submódulo no AppAPT para o appColetaV2 para integração em +apt

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "+apt"]
+	path = +apt
+	url = https://github.com/cragapito/appColetaV2.git


### PR DESCRIPTION
A branch APT deve conter toda a integração e acesso aos recursos do appColetaV2, para testes e preservação do Projeto inicial.

O subprojeto AppAPT (em +apt) conterá os cadernos de testes e funções específicas do módulo.